### PR TITLE
add the ability to view a job at a url and show created_at

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -110,6 +110,11 @@ class DelayedJobWeb < Sinatra::Base
     end
   end
 
+  get '/jobs/:id' do
+    @job = delayed_job.find_by(:id => params[:id])
+    erb :show
+  end
+
   post "/remove/:id" do
     delayed_job.find(params[:id]).delete
     redirect back

--- a/lib/delayed_job_web/application/views/job.erb
+++ b/lib/delayed_job_web/application/views/job.erb
@@ -3,7 +3,7 @@
     <dt>ID</dt>
     <dd>
       <a name="<%= job.id %>"></a>
-      <a href="#<%= job.id %>"><%=h job.id %></a>
+      <a href="<%= u("jobs/#{job.id}") %>"><%=h job.id %></a>
       <div class="controls">
         <form action="<%= u("requeue/#{job.id}") %>" method="post"><%= csrf_token_tag %><input type="submit" value="Retry"></input></form>
         or
@@ -34,6 +34,12 @@
         <div class="backtrace full hide">
           <pre><%=h job.last_error %></pre>
         </div>
+      </dd>
+    <% end %>
+    <% if job.created_at %>
+      <dt>Created At</dt>
+      <dd class="time">
+        <%=h job.created_at.rfc822 %>
       </dd>
     <% end %>
     <% if job.run_at %>

--- a/lib/delayed_job_web/application/views/layout.erb
+++ b/lib/delayed_job_web/application/views/layout.erb
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title>Delayed Job Web</title>
-    <link rel="stylesheet" type="text/css" href="stylesheets/reset.css" />
-    <link rel="stylesheet" type="text/css" href="stylesheets/style.css" />
+    <link rel="stylesheet" type="text/css" href="<%= u('stylesheets/reset.css') %>" />
+    <link rel="stylesheet" type="text/css" href="<%= u('stylesheets/style.css') %>" />
   </head>
   <body>
     <div class="header">

--- a/lib/delayed_job_web/application/views/show.erb
+++ b/lib/delayed_job_web/application/views/show.erb
@@ -1,0 +1,8 @@
+<h1>View Job</h1>
+<% if @job %>
+  <ul class="job">
+    <%= partial :job, {:job => @job} %>
+  </ul>
+<% else %>
+  <p>Job not found!</p>
+<% end %>

--- a/test/integration/test_mounted_in_rails_app.rb
+++ b/test/integration/test_mounted_in_rails_app.rb
@@ -16,4 +16,32 @@ class TestMountedInRailsApp < MiniTest::Unit::TestCase
       assert last_response.ok?, "Received bad response: #{last_response.inspect}"
     end
   end
+
+  def test_show_with_known_job
+    job = OpenStruct.new
+
+    find_by = lambda { | criteria |
+      criteria.must_equal({ :id => "12" })
+      job
+    }
+
+    Delayed::Job.stub(:find_by, find_by) do
+      get "/delayed_job/jobs/12"
+      assert last_response.ok?, "Received bad response: #{last_response.inspect}"
+    end
+  end
+
+  def test_show_without_known_job
+    job = nil
+
+    find_by = lambda { | criteria |
+      criteria.must_equal({ :id => "12" })
+      job
+    }
+
+    Delayed::Job.stub(:find_by, find_by) do
+      get "/delayed_job/jobs/12"
+      assert last_response.ok?, "Received bad response: #{last_response.inspect}"
+    end
+  end
 end

--- a/test/support/delayed_job_fake.rb
+++ b/test/support/delayed_job_fake.rb
@@ -31,4 +31,8 @@ class Delayed::Job
   def self.find(*args)
     DelayedJobFake.new
   end
+
+  def self.find_by(*args)
+    DelayedJobFake.new
+  end
 end


### PR DESCRIPTION
/domain @jmileham

I'm proposing two changes to DJ web on our _public_ fork. We will possibly wanna ask the maintainer to pull these in down the line.
- A show page for any given job
- showing the created_at timestamp in the job details

![image](https://cloud.githubusercontent.com/assets/407586/14255063/70d5eac8-fa60-11e5-8bf3-9e107d4d1627.png)

note: this page is tolerant of the job disappearing (read: deleted)
