### PR TITLE
remove ability to clear all jobs

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -139,11 +139,6 @@ class DelayedJobWeb < Sinatra::Base
     redirect back
   end
 
-  post "/failed/clear" do
-    delayed_jobs(:failed, @queues).delete_all
-    redirect u('failed')
-  end
-
   def delayed_jobs(type, queues = [])
     rel = delayed_job
 

--- a/lib/delayed_job_web/application/views/failed.erb
+++ b/lib/delayed_job_web/application/views/failed.erb
@@ -1,9 +1,5 @@
 <h1>Failed Jobs</h1>
 <% if @jobs.any? %>
-  <form action="<%= u('failed/clear') %>" method="POST">
-    <%= csrf_token_tag %>
-    <input type="submit" value="Clear Failed Jobs"></input>
-  </form>
   <form action="<%= u('requeue/failed') %>" method="POST">
     <%= csrf_token_tag %>
     <input type="submit" value="Retry Failed Jobs"></input>


### PR DESCRIPTION
/domain @samandmoore @jmileham @ceslami 

I was clearing out some stuck jobs the other day when i noticed this very scary button at the top of the page:

![screen shot 2016-07-20 at 10 23 16 am](https://cloud.githubusercontent.com/assets/3477650/16989950/1b2e1d90-4e64-11e6-8ed2-19d5948873f2.png)

I didn't try to click it, but it seems like it just deletes all of the failed jobs without any sort of confirmation/warning. 

I can't imagine ever needing/wanting to use this feature, so i removed it. 

Thoughts?
